### PR TITLE
Refactor(plugin): use object as last parameter

### DIFF
--- a/src/Framework/vite-bt-plugin/babel/bodyDuplicator.ts
+++ b/src/Framework/vite-bt-plugin/babel/bodyDuplicator.ts
@@ -43,13 +43,19 @@ export function bodyDuplicator(path: any) {
   const codeLines = sourceLines.slice(start, end - 1);
   const codeLinesIndent = codeLines.map((line) => line.replace(/^\s{2}/, ''));
 
-  // Add the line contents array as the third argument
-  const stringLiterals = codeLinesIndent.map((line) => t.stringLiteral(line));
-  const lineContentsArray = t.arrayExpression(stringLiterals);
-  path.node.arguments.push(lineContentsArray);
+  // Make the line contents array
+  const lineContentLiterals = codeLinesIndent.map((line) => t.stringLiteral(line));
+  const lineContentsArray = t.arrayExpression(lineContentLiterals);
 
-  // Add the random id as the fourth argument
+  // Make the random id
   const randomId = getRandomId();
-  const idArgument = t.stringLiteral(randomId);
-  path.node.arguments.push(idArgument);
+  const randomIdLiteral = t.stringLiteral(randomId);
+
+  // Make object argument
+  const extraArg = t.objectExpression([
+    t.objectProperty(t.stringLiteral('id'), randomIdLiteral),
+    t.objectProperty(t.stringLiteral('lines'), lineContentsArray),
+  ]);
+
+  path.node.arguments.push(extraArg);
 }

--- a/src/Framework/vite-bt-plugin/fixtures/bodyDuplicator/output.fixture.tsx
+++ b/src/Framework/vite-bt-plugin/fixtures/bodyDuplicator/output.fixture.tsx
@@ -19,17 +19,19 @@ it(
 
     expect(count.innerText).equals('Count: 3');
   },
-  [
-    'const screen = render(<Counter start={0} />);',
-    "const count = screen.getByText('Count: 0');",
-    '',
-    "const increment = screen.getByRole('button', { name: /Inc/ });",
-    '',
-    'for (let i = 0; i < 3; i++) {',
-    '  await userEvent.click(increment);',
-    '}',
-    '',
-    "expect(count.innerText).equals('Count: 3');",
-  ],
-  '6b851eb851eb84'
+  {
+    id: '6b851eb851eb84',
+    lines: [
+      'const screen = render(<Counter start={0} />);',
+      "const count = screen.getByText('Count: 0');",
+      '',
+      "const increment = screen.getByRole('button', { name: /Inc/ });",
+      '',
+      'for (let i = 0; i < 3; i++) {',
+      '  await userEvent.click(increment);',
+      '}',
+      '',
+      "expect(count.innerText).equals('Count: 3');",
+    ],
+  }
 );

--- a/src/Framework/vite-bt-plugin/fixtures/pluginOrder/output.fixture.tsx
+++ b/src/Framework/vite-bt-plugin/fixtures/pluginOrder/output.fixture.tsx
@@ -25,17 +25,19 @@ it(
 
     expect(count.innerText).equals('Count: 3');
   },
-  [
-    'const screen = render(<Counter start={0} />);',
-    "const count = screen.getByText('Count: 0');",
-    '',
-    "const increment = screen.getByRole('button', { name: /Inc/ });",
-    '',
-    'for (let i = 0; i < 3; i++) {',
-    '  await userEvent.click(increment);',
-    '}',
-    '',
-    "expect(count.innerText).equals('Count: 3');",
-  ],
-  '6b851eb851eb84'
+  {
+    id: '6b851eb851eb84',
+    lines: [
+      'const screen = render(<Counter start={0} />);',
+      "const count = screen.getByText('Count: 0');",
+      '',
+      "const increment = screen.getByRole('button', { name: /Inc/ });",
+      '',
+      'for (let i = 0; i < 3; i++) {',
+      '  await userEvent.click(increment);',
+      '}',
+      '',
+      "expect(count.innerText).equals('Count: 3');",
+    ],
+  }
 );

--- a/src/Framework/vite-bt-plugin/transform.test.ts
+++ b/src/Framework/vite-bt-plugin/transform.test.ts
@@ -37,7 +37,7 @@ async function formatCode(code: string) {
   return withLastNewline;
 }
 
-it.only('duplicates method code', async () => {
+it('duplicates method code', async () => {
   const input = await readTsx('./fixtures/bodyDuplicator/input.fixture.tsx');
   const output = await readTsx('./fixtures/bodyDuplicator/output.fixture.tsx');
 

--- a/src/Framework/vite-bt-plugin/transform.test.ts
+++ b/src/Framework/vite-bt-plugin/transform.test.ts
@@ -37,7 +37,7 @@ async function formatCode(code: string) {
   return withLastNewline;
 }
 
-it('duplicates method code', async () => {
+it.only('duplicates method code', async () => {
   const input = await readTsx('./fixtures/bodyDuplicator/input.fixture.tsx');
   const output = await readTsx('./fixtures/bodyDuplicator/output.fixture.tsx');
 


### PR DESCRIPTION
Use single object as last parameter when generating test code instead of multiple arguments.