### PR TITLE
Refactor: rename generator property

### DIFF
--- a/src/Framework/index.ts
+++ b/src/Framework/index.ts
@@ -14,7 +14,7 @@ export interface TestInstance {
   description: string;
   id: string;
   lines: string[];
-  method: TestMethod;
+  generator: TestMethod;
 }
 
 interface TestGeneratedMeta {
@@ -65,7 +65,7 @@ export const tests: TestInstance[] = [];
 
 export function it(description: string, test: TestUserMethod, generatedMeta?: TestGeneratedMeta) {
   const meta = validateGeneratedMeta(generatedMeta);
-  const instance = { description, method: meta.generator, id: meta.id, lines: meta.lines };
+  const instance = { ...meta, description };
   tests.push(instance);
 }
 

--- a/src/Framework/react.ts
+++ b/src/Framework/react.ts
@@ -34,7 +34,7 @@ function useTest() {
 
   function select(test: TestInstance | undefined) {
     setInstance(test);
-    setGenerator(test?.method());
+    setGenerator(test?.generator());
     setCurrentLine(undefined);
     setIsDone(false);
   }


### PR DESCRIPTION
Rename generator property in instance from `method` to `generator`.